### PR TITLE
fix(deploy): prisma migrate deploy fails — missing config and no CLI in prod image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/prisma.config.ts ./prisma.config.ts
 COPY --from=builder /app/src/generated ./src/generated
 
 USER nextjs

--- a/SPEC.md
+++ b/SPEC.md
@@ -116,6 +116,8 @@ enum SourceType { PASTE URL }
 - V17: Editor page use near-full-width layout — side-by-side needs screen real estate
 - V18: View page use wider container on desktop (max-w-[58rem])
 - V19: All pages responsive — editor stacks vertical on mobile, view/home/auth pages readable on small screens
+- V20: `prisma.config.ts` must be present in any container running Prisma CLI — Prisma 7 reads datasource URL from config file, not schema
+- V21: Migrations run in ephemeral one-off container, never inside production app container — app image stays lean, migration failure doesn't affect running app
 
 ## §T — Tasks
 
@@ -142,6 +144,8 @@ enum SourceType { PASTE URL }
 | T19 | x | widen editor layout to near-full-screen | V17,B5 |
 | T20 | x | widen view page container for desktop | V18,B6 |
 | T21 | x | add responsive layout to all pages (editor stack, auth forms, home, header) | V19,B7 |
+| T22 | x | copy `prisma.config.ts` into Docker runner stage | V20,B8 |
+| T23 | . | add `migrate` service to docker-compose.prod.yml (builder target, profiles migrate) + update deploy.sh to use `docker compose run --rm migrate` | V21,B9 |
 
 ## §B — Bugs
 
@@ -154,3 +158,5 @@ enum SourceType { PASTE URL }
 | B5 | 2026-04-25 | editor max-w-7xl too narrow for side-by-side dual pane | widen to near-full-screen, V17 |
 | B6 | 2026-04-25 | view page max-w-3xl too narrow on desktop | widen to max-w-4xl or max-w-5xl, V18 |
 | B7 | 2026-04-25 | no responsive breakpoints — pages unreadable/unusable on mobile | add responsive layout across all pages, V19 |
+| B8 | 2026-04-25 | `prisma.config.ts` not copied into Docker runner stage — Prisma 7 reads datasource URL from config file, `migrate deploy` fails | copy `prisma.config.ts` into runner stage |
+| B9 | 2026-04-25 | runner Docker stage has no prisma CLI — `deploy.sh` runs migration inside app container, `npx` downloads at runtime | use one-off `migrate` service targeting builder stage w/ `profiles: ["migrate"]`, V21 |

--- a/SPEC.md
+++ b/SPEC.md
@@ -145,7 +145,7 @@ enum SourceType { PASTE URL }
 | T20 | x | widen view page container for desktop | V18,B6 |
 | T21 | x | add responsive layout to all pages (editor stack, auth forms, home, header) | V19,B7 |
 | T22 | x | copy `prisma.config.ts` into Docker runner stage | V20,B8 |
-| T23 | . | add `migrate` service to docker-compose.prod.yml (builder target, profiles migrate) + update deploy.sh to use `docker compose run --rm migrate` | V21,B9 |
+| T23 | x | add `migrate` service to docker-compose.prod.yml (builder target, profiles migrate) + update deploy.sh to use `docker compose run --rm migrate` | V21,B9 |
 
 ## §B — Bugs
 

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -41,10 +41,6 @@ if [[ "${1:-}" == "--first-run" ]]; then
     # Build and start
     docker compose -f docker-compose.prod.yml up -d --build
 
-    # Wait for DB
-    log "Waiting for database..."
-    sleep 5
-
     # Run migrations
     log "Running Prisma migrations..."
     docker compose -f docker-compose.prod.yml run --rm migrate

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -47,7 +47,7 @@ if [[ "${1:-}" == "--first-run" ]]; then
 
     # Run migrations
     log "Running Prisma migrations..."
-    docker compose -f docker-compose.prod.yml exec app npx prisma migrate deploy
+    docker compose -f docker-compose.prod.yml run --rm migrate
 
     log "First run complete!"
     log "Next steps:"
@@ -70,7 +70,7 @@ else
 
     # Run any new migrations
     log "Running migrations..."
-    docker compose -f docker-compose.prod.yml exec app npx prisma migrate deploy
+    docker compose -f docker-compose.prod.yml run --rm migrate
 
     log "Deploy complete!"
     log "If Nginx config changed: sudo cp deploy/nginx/markview.conf /etc/nginx/sites-available/ && sudo nginx -t && sudo systemctl reload nginx"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -39,6 +39,7 @@ services:
       dockerfile: Dockerfile
       target: builder
     command: npx prisma migrate deploy
+    restart: "no"
     env_file:
       - .env.production
     depends_on:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,6 +33,22 @@ services:
     networks:
       - markview
 
+  migrate:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: builder
+    command: npx prisma migrate deploy
+    env_file:
+      - .env.production
+    depends_on:
+      db:
+        condition: service_healthy
+    profiles:
+      - migrate
+    networks:
+      - markview
+
 volumes:
   pgdata:
 


### PR DESCRIPTION
## Summary

- Copy `prisma.config.ts` into Docker runner stage — Prisma 7 reads datasource URL from this file, not `schema.prisma`
- Add ephemeral `migrate` service to `docker-compose.prod.yml` targeting builder stage (has Prisma CLI)
- Update `deploy.sh` to use `docker compose run --rm migrate` instead of `exec` into app container

## Root cause

GH issue #1 identified two problems. Investigation revealed the actual root cause differs from the issue description:

1. **Issue said**: schema.prisma missing `url = env("DATABASE_URL")` — **Actual**: Prisma 7 moved datasource URL to `prisma.config.ts` (already correct), but file wasn't copied into Docker image
2. **Issue said**: Prisma CLI not in runner stage — **Actual**: confirmed. `npx` downloads at runtime, slow + fragile + interactive prompt

## Changes

- `Dockerfile` — add `COPY --from=builder /app/prisma.config.ts` to runner stage
- `docker-compose.prod.yml` — add `migrate` service (builder target, `profiles: ["migrate"]`)
- `deploy/scripts/deploy.sh` — replace `exec app npx prisma migrate deploy` with `run --rm migrate`
- `SPEC.md` — add V20, V21 invariants + B8, B9 bug entries + T22, T23 tasks

## Test plan

- [ ] Run `docker compose -f docker-compose.prod.yml build` — all stages build successfully
- [ ] Run `./deploy/scripts/deploy.sh --first-run` — migrations execute via ephemeral container
- [ ] Verify app container has `prisma.config.ts` present
- [ ] Verify migrate container exits cleanly after migration

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)