### PR TITLE
fix(deploy): move cloudflare-ips include inside nginx server block

### DIFF
--- a/PRODUCTION.md
+++ b/PRODUCTION.md
@@ -78,6 +78,7 @@ This builds containers, starts services, runs DB migrations, and renders Nginx c
 sudo cp deploy/nginx/markview.conf /etc/nginx/sites-available/
 sudo cp deploy/nginx/proxy-params.conf /etc/nginx/snippets/
 sudo cp deploy/nginx/cloudflare-ips.conf /etc/nginx/snippets/
+sudo cp deploy/nginx/cloudflare-realip-geo.conf /etc/nginx/conf.d/
 sudo ln -s /etc/nginx/sites-available/markview.conf /etc/nginx/sites-enabled/
 sudo nginx -t && sudo systemctl reload nginx
 ```
@@ -85,9 +86,10 @@ sudo nginx -t && sudo systemctl reload nginx
 For RHEL/Alma (no `sites-available`):
 
 ```bash
-sudo cp deploy/nginx/markview.conf /etc/nginx/conf.d/
+sudo cp deploy/nginx/markview.conf /etc/nginx/conf.d/markview.conf
 sudo cp deploy/nginx/proxy-params.conf /etc/nginx/snippets/
 sudo cp deploy/nginx/cloudflare-ips.conf /etc/nginx/snippets/
+sudo cp deploy/nginx/cloudflare-realip-geo.conf /etc/nginx/conf.d/
 sudo nginx -t && sudo systemctl reload nginx
 ```
 
@@ -140,7 +142,7 @@ gunzip < /var/backups/markview/markview_20260425_020000.sql.gz | \
 ## Security Checklist
 
 - [ ] Cloudflare SSL mode set to Full (Strict)
-- [ ] Nginx only accepts Cloudflare IPs (`deny all` + CF allowlist)
+- [ ] Nginx only accepts Cloudflare IPs (`geo $realip_remote_addr` allowlist)
 - [ ] Firewall only opens ports 80, 443, SSH
 - [ ] SSH uses key auth, password auth disabled
 - [ ] fail2ban running on SSH
@@ -162,7 +164,8 @@ gunzip < /var/backups/markview/markview_20260425_020000.sql.gz | \
 | `.env.production.example` | Production env var template |
 | `deploy/nginx/markview.conf.template` | Nginx config template (`${DOMAIN}` substituted at deploy) |
 | `deploy/nginx/proxy-params.conf` | Shared proxy header snippet |
-| `deploy/nginx/cloudflare-ips.conf` | Cloudflare IP allowlist + real_ip config |
+| `deploy/nginx/cloudflare-ips.conf` | Cloudflare `set_real_ip_from` config |
+| `deploy/nginx/cloudflare-realip-geo.conf` | Cloudflare IP access control (`geo` block, http context) |
 | `deploy/scripts/deploy.sh` | Build and deploy script |
 | `deploy/scripts/backup-db.sh` | Database backup with rotation |
 | `deploy/scripts/update-cloudflare-ips.sh` | Cloudflare IP range updater |

--- a/SPEC.md
+++ b/SPEC.md
@@ -118,6 +118,7 @@ enum SourceType { PASTE URL }
 - V19: All pages responsive — editor stacks vertical on mobile, view/home/auth pages readable on small screens
 - V20: `prisma.config.ts` must be present in any container running Prisma CLI — Prisma 7 reads datasource URL from config file, not schema
 - V21: Migrations run in ephemeral one-off container, never inside production app container — app image stays lean, migration failure doesn't affect running app
+- V22: Nginx `allow`/`deny` directives and `include cloudflare-ips.conf` must be in same context (server block) — nginx evaluates access control per-context
 
 ## §T — Tasks
 
@@ -146,6 +147,7 @@ enum SourceType { PASTE URL }
 | T21 | x | add responsive layout to all pages (editor stack, auth forms, home, header) | V19,B7 |
 | T22 | x | copy `prisma.config.ts` into Docker runner stage | V20,B8 |
 | T23 | x | add `migrate` service to docker-compose.prod.yml (builder target, profiles migrate) + update deploy.sh to use `docker compose run --rm migrate` | V21,B9 |
+| T24 | x | move `include cloudflare-ips.conf` inside server block before `deny all` in nginx template | V22,B10 |
 
 ## §B — Bugs
 
@@ -160,3 +162,4 @@ enum SourceType { PASTE URL }
 | B7 | 2026-04-25 | no responsive breakpoints — pages unreadable/unusable on mobile | add responsive layout across all pages, V19 |
 | B8 | 2026-04-25 | `prisma.config.ts` not copied into Docker runner stage — Prisma 7 reads datasource URL from config file, `migrate deploy` fails | copy `prisma.config.ts` into runner stage |
 | B9 | 2026-04-25 | runner Docker stage has no prisma CLI — `deploy.sh` runs migration inside app container, `npx` downloads at runtime | use one-off `migrate` service targeting builder stage w/ `profiles: ["migrate"]`, V21 |
+| B10 | 2026-04-25 | `include cloudflare-ips.conf` at http context, `deny all` inside server block — different nginx contexts, allow directives never reach server block → all requests 403 | move include inside server block before `deny all`, V22 |

--- a/SPEC.md
+++ b/SPEC.md
@@ -118,7 +118,7 @@ enum SourceType { PASTE URL }
 - V19: All pages responsive — editor stacks vertical on mobile, view/home/auth pages readable on small screens
 - V20: `prisma.config.ts` must be present in any container running Prisma CLI — Prisma 7 reads datasource URL from config file, not schema
 - V21: Migrations run in ephemeral one-off container, never inside production app container — app image stays lean, migration failure doesn't affect running app
-- V22: Nginx `allow`/`deny` directives and `include cloudflare-ips.conf` must be in same context (server block) — nginx evaluates access control per-context
+- V22: Nginx access control must use `geo $realip_remote_addr` block (http context), not `allow`/`deny` — `set_real_ip_from` rewrites `$remote_addr` to visitor IP before `allow`/`deny` evaluates, so `deny all` blocks real visitors
 
 ## §T — Tasks
 
@@ -148,6 +148,7 @@ enum SourceType { PASTE URL }
 | T22 | x | copy `prisma.config.ts` into Docker runner stage | V20,B8 |
 | T23 | x | add `migrate` service to docker-compose.prod.yml (builder target, profiles migrate) + update deploy.sh to use `docker compose run --rm migrate` | V21,B9 |
 | T24 | x | move `include cloudflare-ips.conf` inside server block before `deny all` in nginx template | V22,B10 |
+| T25 | x | replace `allow`/`deny` with `geo $realip_remote_addr` block — `set_real_ip_from` rewrites `$remote_addr` before access check | V22,B10 |
 
 ## §B — Bugs
 
@@ -162,4 +163,4 @@ enum SourceType { PASTE URL }
 | B7 | 2026-04-25 | no responsive breakpoints — pages unreadable/unusable on mobile | add responsive layout across all pages, V19 |
 | B8 | 2026-04-25 | `prisma.config.ts` not copied into Docker runner stage — Prisma 7 reads datasource URL from config file, `migrate deploy` fails | copy `prisma.config.ts` into runner stage |
 | B9 | 2026-04-25 | runner Docker stage has no prisma CLI — `deploy.sh` runs migration inside app container, `npx` downloads at runtime | use one-off `migrate` service targeting builder stage w/ `profiles: ["migrate"]`, V21 |
-| B10 | 2026-04-25 | `include cloudflare-ips.conf` at http context, `deny all` inside server block — different nginx contexts, allow directives never reach server block → all requests 403 | move include inside server block before `deny all`, V22 |
+| B10 | 2026-04-25 | `set_real_ip_from` rewrites `$remote_addr` to visitor IP before `allow`/`deny` evaluates — `deny all` blocks real visitors even when Cloudflare IP is the socket peer | replace `allow`/`deny` with `geo $realip_remote_addr` block that checks original socket IP, V22 |

--- a/deploy/nginx/cloudflare-ips.conf
+++ b/deploy/nginx/cloudflare-ips.conf
@@ -23,27 +23,3 @@ set_real_ip_from 2405:b500::/32;
 set_real_ip_from 2405:8100::/32;
 set_real_ip_from 2a06:98c0::/29;
 set_real_ip_from 2c0f:f248::/32;
-
-# Allow Cloudflare IPs
-allow 173.245.48.0/20;
-allow 103.21.244.0/22;
-allow 103.22.200.0/22;
-allow 103.31.4.0/22;
-allow 141.101.64.0/18;
-allow 108.162.192.0/18;
-allow 190.93.240.0/20;
-allow 188.114.96.0/20;
-allow 197.234.240.0/22;
-allow 198.41.128.0/17;
-allow 162.158.0.0/15;
-allow 104.16.0.0/13;
-allow 104.24.0.0/14;
-allow 172.64.0.0/13;
-allow 131.0.72.0/22;
-allow 2400:cb00::/32;
-allow 2606:4700::/32;
-allow 2803:f800::/32;
-allow 2405:b500::/32;
-allow 2405:8100::/32;
-allow 2a06:98c0::/29;
-allow 2c0f:f248::/32;

--- a/deploy/nginx/cloudflare-realip-geo.conf
+++ b/deploy/nginx/cloudflare-realip-geo.conf
@@ -1,0 +1,34 @@
+# Placed in http {} context (via conf.d/).
+# Uses $realip_remote_addr — the original socket IP before real_ip rewrites
+# $remote_addr to the visitor IP. This lets us restrict access to Cloudflare
+# edge IPs even after set_real_ip_from has run.
+
+geo $realip_remote_addr $is_cloudflare {
+    default 0;
+
+    # Cloudflare IPv4 — https://www.cloudflare.com/ips-v4/
+    173.245.48.0/20  1;
+    103.21.244.0/22  1;
+    103.22.200.0/22  1;
+    103.31.4.0/22    1;
+    141.101.64.0/18  1;
+    108.162.192.0/18 1;
+    190.93.240.0/20  1;
+    188.114.96.0/20  1;
+    197.234.240.0/22 1;
+    198.41.128.0/17  1;
+    162.158.0.0/15   1;
+    104.16.0.0/13    1;
+    104.24.0.0/14    1;
+    172.64.0.0/13    1;
+    131.0.72.0/22    1;
+
+    # Cloudflare IPv6 — https://www.cloudflare.com/ips-v6/
+    2400:cb00::/32   1;
+    2606:4700::/32   1;
+    2803:f800::/32   1;
+    2405:b500::/32   1;
+    2405:8100::/32   1;
+    2a06:98c0::/29   1;
+    2c0f:f248::/32   1;
+}

--- a/deploy/nginx/markview.conf.template
+++ b/deploy/nginx/markview.conf.template
@@ -1,6 +1,3 @@
-# Cloudflare IP ranges — update periodically via update-cloudflare-ips.sh
-include /etc/nginx/snippets/cloudflare-ips.conf;
-
 # Rate limiting — keyed on real visitor IP (CF-Connecting-IP)
 limit_req_zone $http_cf_connecting_ip zone=markview_api:10m rate=10r/s;
 limit_req_zone $http_cf_connecting_ip zone=markview_login:10m rate=3r/m;
@@ -16,6 +13,7 @@ server {
     ssl_ciphers         HIGH:!aNULL:!MD5;
 
     # Only allow Cloudflare IPs
+    include /etc/nginx/snippets/cloudflare-ips.conf;
     deny all;
 
     # Restore real visitor IP from Cloudflare
@@ -53,6 +51,5 @@ server {
 server {
     listen 80;
     server_name ${DOMAIN};
-    deny all;
     return 301 https://$host$request_uri;
 }

--- a/deploy/nginx/markview.conf.template
+++ b/deploy/nginx/markview.conf.template
@@ -12,12 +12,14 @@ server {
     ssl_protocols       TLSv1.2 TLSv1.3;
     ssl_ciphers         HIGH:!aNULL:!MD5;
 
-    # Only allow Cloudflare IPs
-    include /etc/nginx/snippets/cloudflare-ips.conf;
-    deny all;
-
     # Restore real visitor IP from Cloudflare
+    include /etc/nginx/snippets/cloudflare-ips.conf;
     real_ip_header CF-Connecting-IP;
+
+    # Only allow Cloudflare IPs (checked against original socket IP)
+    if ($is_cloudflare = 0) {
+        return 403;
+    }
 
     # Security headers
     server_tokens off;

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -50,10 +50,11 @@ if [[ "${1:-}" == "--first-run" ]]; then
     log "  1. sudo cp deploy/nginx/markview.conf /etc/nginx/sites-available/"
     log "  2. sudo cp deploy/nginx/proxy-params.conf /etc/nginx/snippets/"
     log "  3. sudo cp deploy/nginx/cloudflare-ips.conf /etc/nginx/snippets/"
-    log "  4. sudo ln -s /etc/nginx/sites-available/markview.conf /etc/nginx/sites-enabled/"
-    log "  5. Place Cloudflare origin cert at /etc/ssl/cloudflare/${DOMAIN}.pem and .key"
-    log "  6. sudo nginx -t && sudo systemctl reload nginx"
-    log "  7. Set ENABLE_REGISTER=true, create account, then set back to false"
+    log "  4. sudo cp deploy/nginx/cloudflare-realip-geo.conf /etc/nginx/conf.d/"
+    log "  5. sudo ln -s /etc/nginx/sites-available/markview.conf /etc/nginx/sites-enabled/"
+    log "  6. Place Cloudflare origin cert at /etc/ssl/cloudflare/${DOMAIN}.pem and .key"
+    log "  7. sudo nginx -t && sudo systemctl reload nginx"
+    log "  8. Set ENABLE_REGISTER=true, create account, then set back to false"
 else
     log "Pulling latest code..."
     git pull --ff-only

--- a/deploy/scripts/update-cloudflare-ips.sh
+++ b/deploy/scripts/update-cloudflare-ips.sh
@@ -4,39 +4,54 @@
 
 set -euo pipefail
 
-CONF="/etc/nginx/snippets/cloudflare-ips.conf"
-TMP=$(mktemp)
+REALIP_CONF="/etc/nginx/snippets/cloudflare-ips.conf"
+GEO_CONF="/etc/nginx/conf.d/cloudflare-realip-geo.conf"
+TMP_REALIP=$(mktemp)
+TMP_GEO=$(mktemp)
 
-echo "# Cloudflare IPs — auto-updated $(date -I)" > "$TMP"
-echo "# Source: https://www.cloudflare.com/ips/" >> "$TMP"
-echo "" >> "$TMP"
+IPV4=$(curl -sf https://www.cloudflare.com/ips-v4/)
+IPV6=$(curl -sf https://www.cloudflare.com/ips-v6/)
 
-echo "# IPv4" >> "$TMP"
-for ip in $(curl -sf https://www.cloudflare.com/ips-v4/); do
-    echo "set_real_ip_from $ip;" >> "$TMP"
-done
+# --- cloudflare-ips.conf (set_real_ip_from only) ---
+{
+    echo "# Cloudflare IPs — auto-updated $(date -I)"
+    echo "# Source: https://www.cloudflare.com/ips/"
+    echo ""
+    echo "# IPv4"
+    for ip in $IPV4; do echo "set_real_ip_from $ip;"; done
+    echo ""
+    echo "# IPv6"
+    for ip in $IPV6; do echo "set_real_ip_from $ip;"; done
+} > "$TMP_REALIP"
 
-echo "" >> "$TMP"
-echo "# IPv6" >> "$TMP"
-for ip in $(curl -sf https://www.cloudflare.com/ips-v6/); do
-    echo "set_real_ip_from $ip;" >> "$TMP"
-done
+# --- cloudflare-realip-geo.conf (geo block for access control) ---
+{
+    echo "# Cloudflare IP access control — auto-updated $(date -I)"
+    echo "# Uses \$realip_remote_addr (original socket IP before real_ip rewrite)"
+    echo ""
+    echo "geo \$realip_remote_addr \$is_cloudflare {"
+    echo "    default 0;"
+    echo ""
+    echo "    # IPv4"
+    for ip in $IPV4; do printf "    %-20s 1;\n" "$ip"; done
+    echo ""
+    echo "    # IPv6"
+    for ip in $IPV6; do printf "    %-20s 1;\n" "$ip"; done
+    echo "}"
+} > "$TMP_GEO"
 
-echo "" >> "$TMP"
-echo "# Allow Cloudflare IPs" >> "$TMP"
-for ip in $(curl -sf https://www.cloudflare.com/ips-v4/) $(curl -sf https://www.cloudflare.com/ips-v6/); do
-    echo "allow $ip;" >> "$TMP"
-done
-
-# Validate nginx config before applying
-cp "$CONF" "${CONF}.bak"
-mv "$TMP" "$CONF"
+# Backup and apply
+cp "$REALIP_CONF" "${REALIP_CONF}.bak"
+cp "$GEO_CONF" "${GEO_CONF}.bak"
+mv "$TMP_REALIP" "$REALIP_CONF"
+mv "$TMP_GEO" "$GEO_CONF"
 
 if nginx -t 2>/dev/null; then
     nginx -s reload
     echo "Cloudflare IPs updated and Nginx reloaded."
 else
     echo "Nginx config test failed! Rolling back."
-    mv "${CONF}.bak" "$CONF"
+    mv "${REALIP_CONF}.bak" "$REALIP_CONF"
+    mv "${GEO_CONF}.bak" "$GEO_CONF"
     exit 1
 fi


### PR DESCRIPTION
### **User description**
## Summary

- Moved `include /etc/nginx/snippets/cloudflare-ips.conf` from http context into the server block, before `deny all`
- Removed unnecessary `deny all` from HTTP→HTTPS redirect server block
- Updated SPEC.md: added V22 invariant, B10 bug entry, T24 task

## Root Cause

Nginx evaluates `allow`/`deny` directives per-context. The `include` was at http level while `deny all` was inside the server block — the server block never saw the `allow` directives, so all requests got 403.

## Testing

- [ ] Deploy to staging, verify app loads through Cloudflare
- [ ] Verify direct non-Cloudflare IPs are still denied
- [ ] Run `nginx -t` to validate config syntax

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Move `cloudflare-ips.conf` include inside nginx server block

- Fix allow/deny context mismatch causing 403 on all requests

- Remove unnecessary `deny all` from HTTP→HTTPS redirect block

- Update SPEC.md with V22 invariant, B10 bug, T24 task


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Before["http context: include cloudflare-ips.conf (allow)"]
  ServerBefore["server block: deny all (no allow)"]
  Before -- "different contexts" --> ServerBefore
  ServerBefore -- "result" --> Block403["403 all requests"]

  After["server block: include cloudflare-ips.conf + deny all"]
  After -- "same context" --> Allow["Cloudflare IPs allowed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>markview.conf.template</strong><dd><code>Fix cloudflare-ips include context for access control</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deploy/nginx/markview.conf.template

<ul><li>Removed <code>include /etc/nginx/snippets/cloudflare-ips.conf</code> from http <br>context (outside server block)<br> <li> Added the same <code>include</code> inside the <code>server</code> block, directly before <code>deny </code><br><code>all</code><br> <li> Removed unnecessary <code>deny all</code> from the HTTP→HTTPS redirect server block</ul>


</details>


  </td>
  <td><a href="https://github.com/rendyuwu/markview/pull/4/files#diff-3cfcb24b2530a704fe170a6db6353a52f00af9cbc09235b30171a1ff67e204ca">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SPEC.md</strong><dd><code>Document nginx context bug and fix in spec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

SPEC.md

<ul><li>Added V22 invariant: nginx allow/deny and cloudflare-ips include must <br>share same context<br> <li> Added T24 task entry for moving the include inside the server block<br> <li> Added B10 bug entry documenting the http vs server context mismatch</ul>


</details>


  </td>
  <td><a href="https://github.com/rendyuwu/markview/pull/4/files#diff-7426c9e3a694ca6015df5f98637912975f2edea23270203ee89a8bdeed246ee0">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

